### PR TITLE
Bind *calls* with with-redef

### DIFF
--- a/src/stubadub/core.clj
+++ b/src/stubadub/core.clj
@@ -6,13 +6,13 @@
   (let [has-return-value? (= :returns (first opts-and-body))
         body (if has-return-value? (nnext opts-and-body) opts-and-body)
         return-value (when has-return-value? (second opts-and-body))]
-    `(binding [*calls* (if (bound? #'*calls*)
-                         *calls* (atom []))]
-       (with-redefs [~func (fn [& args#]
-                             (swap! *calls*
-                                    conj {:func ~func, :args args#})
-                             ~return-value)]
-         ~@body))))
+    `(with-redefs [*calls* (if (bound? #'*calls*)
+                             *calls* (atom []))
+                   ~func (fn [& args#]
+                           (swap! *calls*
+                                  conj {:func ~func, :args args#})
+                           ~return-value)]
+       ~@body)))
 
 (defn calls-to [func]
   (if (bound? #'*calls*)


### PR DESCRIPTION
This allows stubadub to work across threads. 

Currently, stubadub throws exception if the call to the stubbed out function occurs in a different thread. As stubadub already bind the stubbed function across threads with with-redefs, it makes sense to do the same with the `*calls*` atom.

Alas, binding with with-redefs makes stubadub inappropriate for use in test suites running across multiple threads as with-redefs will alter the root binding for the stubbed function across threads. Maybe another pull request for the README.md is in order :)
