### PR TITLE
Allow providing return values by arguments to stubbed out function

### DIFF
--- a/src/stubadub/core.clj
+++ b/src/stubadub/core.clj
@@ -4,14 +4,22 @@
 
 (defmacro with-stub [func & opts-and-body]
   (let [has-return-value? (= :returns (first opts-and-body))
-        body (if has-return-value? (nnext opts-and-body) opts-and-body)
-        return-value (when has-return-value? (second opts-and-body))]
+        has-return-value-by-args? (= :returns-by-args (first opts-and-body))
+        has-opts? (or has-return-value? has-return-value-by-args?)
+        body (if has-opts?
+               (nnext opts-and-body)
+               opts-and-body)
+        return-value (when has-opts? (second opts-and-body))
+        args (gensym)]
     `(with-redefs [*calls* (if (bound? #'*calls*)
                              *calls* (atom []))
-                   ~func (fn [& args#]
+                   ~func (fn [& ~args]
                            (swap! *calls*
-                                  conj {:func ~func, :args args#})
-                           ~return-value)]
+                                  conj {:func ~func, :args ~args})
+                           ~(cond
+                              has-return-value? return-value
+                              has-return-value-by-args? `(get ~return-value ~args)
+                              :else nil))]
        ~@body)))
 
 (defn calls-to [func]

--- a/test/stubadub/core_test.clj
+++ b/test/stubadub/core_test.clj
@@ -17,10 +17,25 @@
         (with-stub slurp :returns "not read from disk"
           (slurp "test3.txt")))
 
+;; return values by args can be specified
+
+(def returns-by-args {["test4.txt" :x :y] "not read from disk"
+                      ["test5.txt" :y :z] "not read from disk either"})
+
+(expect ["not read from disk"
+         "not read from disk either"
+         nil]
+        (with-stub slurp
+          :returns-by-args {["test4.txt" :x :y] "not read from disk"
+                            ["test5.txt" :y :z] "not read from disk either"}
+          [(slurp "test4.txt" :x :y)
+           (slurp "test5.txt" :y :z)
+           (slurp "test5.txt" :not :matching)]))
+
 ;; you can nest several stubs
 
-(expect [["test4.txt" "not read from disk either"]]
+(expect [["test6.txt" "not read from disk either"]]
         (with-stub spit
           (with-stub slurp :returns "not read from disk either"
-            (spit "test4.txt" (slurp "test5.txt"))
+            (spit "test6.txt" (slurp "test7.txt"))
             (calls-to spit))))


### PR DESCRIPTION
Based off changes in pull request #1, advice if you'd like this worked off master.
