### PR TITLE
Evaluate `:return-fn` compile-time

### DIFF
--- a/src/stubadub/core.cljc
+++ b/src/stubadub/core.cljc
@@ -9,18 +9,18 @@
         body (if has-opts?
                (nnext opts-and-body)
                opts-and-body)
-        return-value (when has-opts? (second opts-and-body))
         args (gensym)]
-    `(with-redefs [*calls* (if @*calls*
-                             *calls* (atom []))
-                   ~func (fn [& ~args]
-                           (swap! *calls*
-                                  conj {:func ~func, :args ~args})
-                           ~(cond
-                              has-return-value? return-value
-                              has-return-fn? `(~return-value ~args)
-                              :else nil))]
-       ~@body)))
+    `(let [return-value# ~(when has-opts? (second opts-and-body))]
+       (with-redefs [*calls* (if @*calls*
+                               *calls* (atom []))
+                     ~func (fn [& ~args]
+                             (swap! *calls*
+                                    conj {:func ~func, :args ~args})
+                             (cond
+                               ~has-return-value? return-value#
+                               ~has-return-fn? (return-value# ~args)
+                               :else nil))]
+         ~@body))))
 
 (defn calls-to [func]
   (if @*calls*

--- a/test/stubadub/core_test.cljc
+++ b/test/stubadub/core_test.cljc
@@ -28,6 +28,22 @@
            [(slurp "test4.txt" :x :y)
             (slurp "test5.txt" :y :z)]))))
 
+(defn return-in-sequence [vals]
+  (let [retvals (atom vals)]
+    (fn [& _]
+      (when-let [v (first @retvals)]
+        (swap! retvals next)
+        v))))
+
+(deftest does-not-re-evaluate-return-fn-for-every-call
+  (is (= ["test4.txt not read from disk"
+          "test5.txt not read from disk"]
+         (with-stub slurp
+           :return-fn (return-in-sequence ["test4.txt not read from disk"
+                                           "test5.txt not read from disk"])
+           [(slurp "test4.txt" :x :y)
+            (slurp "test5.txt" :y :z)]))))
+
 (deftest you-can-nest-several-stubs
   (is (= [["test6.txt" "not read from disk either"]]
          (with-stub spit


### PR DESCRIPTION
This fixes what I would consider to be a bug where stubadub would re-evaluate the expression for `:return-fn` on every call to the stubbed function. This behavior necessitates the use of a let or similar to create stateful stubs. Stateful stuff isn't nice, but neither are stubs, so what are ya gonna do?